### PR TITLE
Changed whole API to pass pointers rather than structures.

### DIFF
--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -73,7 +73,7 @@ typedef struct Window {
   GLint S2D_GL_MINOR_VERSION;
   const GLubyte *S2D_GL_SHADING_LANGUAGE_VERSION;
   SDL_GLContext glcontext;
-  char *title;
+  const char *title;
   int width;    // actual dimentions
   int height;
   int s_width;  // scaled dimentions
@@ -108,7 +108,7 @@ typedef struct Text {
   GLuint texture_id;
   Color color;
   TTF_Font *font;
-  char *msg;
+  const char *msg;
   int x;
   int y;
   int w;
@@ -140,8 +140,8 @@ void S2D_GL_DrawTriangle(
   GLfloat c2r, GLfloat c2g, GLfloat c2b, GLfloat c2a,
   GLfloat x3,  GLfloat y3,
   GLfloat c3r, GLfloat c3g, GLfloat c3b, GLfloat c3a);
-void S2D_GL_DrawImage(Image img);
-void S2D_GL_DrawText(Text txt);
+void S2D_GL_DrawImage(Image *img);
+void S2D_GL_DrawText(Text *txt);
 void S2D_GL_FreeTexture(GLuint *id);
 void S2D_GL_Clear(Color clr);
 
@@ -158,8 +158,8 @@ void S2D_GL_Clear(Color clr);
     GLfloat c2r, GLfloat c2g, GLfloat c2b, GLfloat c2a,
     GLfloat x3,  GLfloat y3,
     GLfloat c3r, GLfloat c3g, GLfloat c3b, GLfloat c3a);
-  void gles_draw_image(Image img);
-  void gles_draw_text(Text txt);
+  void gles_draw_image(Image *img);
+  void gles_draw_text(Text *txt);
 #else
   void gl2_hello();
   void gl3_hello();
@@ -183,10 +183,10 @@ void S2D_GL_Clear(Color clr);
     GLfloat c2r, GLfloat c2g, GLfloat c2b, GLfloat c2a,
     GLfloat x3,  GLfloat y3,
     GLfloat c3r, GLfloat c3g, GLfloat c3b, GLfloat c3a);
-  void gl2_draw_image(Image img);
-  void gl3_draw_image(Image img);
-  void gl2_draw_text(Text txt);
-  void gl3_draw_text(Text txt);
+  void gl2_draw_image(Image *img);
+  void gl3_draw_image(Image *img);
+  void gl2_draw_text(Text *txt);
+  void gl3_draw_text(Text *txt);
 #endif
 
 // S2D Functions ///////////////////////////////////////////////////////////////
@@ -194,12 +194,12 @@ void S2D_GL_Clear(Color clr);
 /*
  * Logs standard messages to the console
  */
-void S2D_Log(char *msg, int type);
+void S2D_Log(const char *msg, int type);
 
 /*
  * Logs Simple 2D errors to the console, with caller and message body
  */
-void S2D_Error(char *caller, const char *msg);
+void S2D_Error(const char *caller, const char *msg);
 
 /*
  * Enable/disable logging of diagnostics
@@ -215,7 +215,7 @@ void print_gl_context();
  * Create the window
  */
 Window* S2D_CreateWindow(
-  char *title, int width, int height, Update, Render, int flags
+  const char *title, int width, int height, Update, Render, int flags
 );
 
 /*
@@ -257,62 +257,62 @@ void S2D_DrawQuad(
 /*
  * Create an image
  */
-Image S2D_CreateImage(char *path);
+Image *S2D_CreateImage(const char *path);
 
 /*
  * Draw an image
  */
-void S2D_DrawImage(Image img);
+void S2D_DrawImage(Image *img);
 
 /*
  * Free an image
  */
-void S2D_FreeImage(Image img);
+void S2D_FreeImage(Image *img);
 
 /*
  * Create text
  */
-Text S2D_CreateText(char *font, char *msg, int size);
+Text *S2D_CreateText(const char *font, const char *msg, int size);
 
 /*
 * Sets the text message
 */
-void S2D_SetText(Text *txt, char *msg);
+void S2D_SetText(Text *txt, const char *msg);
 
 /*
  * Draw text
  */
-void S2D_DrawText(Text txt);
+void S2D_DrawText(Text *txt);
 
 /*
  * Free the text
  */
-void S2D_FreeText(Text txt);
+void S2D_FreeText(Text *txt);
 
 /*
  * Create a sound
  */
-Sound S2D_CreateSound(char *path);
+Sound *S2D_CreateSound(const char *path);
 
 /*
  * Play the sound
  */
-void S2D_PlaySound(Sound sound);
+void S2D_PlaySound(Sound *sound);
 
 /*
  * Free the sound
  */
-void S2D_FreeSound(Sound sound);
+void S2D_FreeSound(Sound *sound);
 
 /*
  * Create music
  */
-Music S2D_CreateMusic(char *path);
+Music *S2D_CreateMusic(const char *path);
 
 /*
  * Play the music
  */
-void S2D_PlayMusic(Music music, int times);
+void S2D_PlayMusic(Music *music, int times);
 
 /*
  * Pause the playing music
@@ -337,4 +337,5 @@ void S2D_FadeOutMusic(int ms);
 /*
  * Free the music
  */
-void S2D_FreeMusic(Music music);
+void S2D_FreeMusic(Music *music);
+

--- a/src/gl.c
+++ b/src/gl.c
@@ -185,7 +185,7 @@ void S2D_GL_DrawTriangle(GLfloat x1,  GLfloat y1,
 /*
  * Draw an image
  */
-void S2D_GL_DrawImage(Image img) {
+void S2D_GL_DrawImage(Image *img) {
   #if GLES
     gles_draw_image(img);
   #else
@@ -201,7 +201,7 @@ void S2D_GL_DrawImage(Image img) {
 /*
  * Draw text
  */
-void S2D_GL_DrawText(Text txt) {
+void S2D_GL_DrawText(Text *txt) {
   #if GLES
     gles_draw_text(txt);
   #else

--- a/src/gl2.c
+++ b/src/gl2.c
@@ -82,11 +82,11 @@ static void gl2_draw_texture(int x, int y, int w, int h,
 /*
  * Draw image
  */
-void gl2_draw_image(Image img) {
+void gl2_draw_image(Image *img) {
   gl2_draw_texture(
-    img.x, img.y, img.w, img.h,
+    img->x, img->y, img->w, img->h,
     1.f, 1.f, 1.f, 1.f,
-    img.texture_id
+    img->texture_id
   );
 }
 
@@ -94,10 +94,10 @@ void gl2_draw_image(Image img) {
 /*
  * Draw text
  */
-void gl2_draw_text(Text txt) {
+void gl2_draw_text(Text *txt) {
   gl2_draw_texture(
-    txt.x, txt.y, txt.w, txt.h,
-    txt.color.r, txt.color.g, txt.color.b, txt.color.a,
-    txt.texture_id
+    txt->x, txt->y, txt->w, txt->h,
+    txt->color.r, txt->color.g, txt->color.b, txt->color.a,
+    txt->texture_id
   );
 }

--- a/src/gl3.c
+++ b/src/gl3.c
@@ -224,11 +224,11 @@ static void gl3_draw_texture(int x, int y, int w, int h,
 /*
  * Draw image
  */
-void gl3_draw_image(Image img) {
+void gl3_draw_image(Image *img) {
   gl3_draw_texture(
-    img.x, img.y, img.w, img.h,
+    img->x, img->y, img->w, img->h,
     1.f, 1.f, 1.f, 1.f,
-    img.texture_id
+    img->texture_id
   );
 }
 
@@ -236,10 +236,10 @@ void gl3_draw_image(Image img) {
 /*
  * Draw text
  */
-void gl3_draw_text(Text txt) {
+void gl3_draw_text(Text *txt) {
   gl3_draw_texture(
-    txt.x, txt.y, txt.w, txt.h, 
-    txt.color.r, txt.color.g, txt.color.b, txt.color.a,
-    txt.texture_id
+    txt->x, txt->y, txt->w, txt->h, 
+    txt->color.r, txt->color.g, txt->color.b, txt->color.a,
+    txt->texture_id
   );
 }

--- a/src/gles.c
+++ b/src/gles.c
@@ -210,7 +210,7 @@ void gles_draw_triangle(GLfloat x1,  GLfloat y1,
 /*
  * Draw image
  */
-void gles_draw_image(Image img) {
+void gles_draw_image(Image *img) {
   // TODO: Implement this
 }
 
@@ -218,6 +218,6 @@ void gles_draw_image(Image img) {
 /*
  * Draw text
  */
-void gles_draw_text(Text txt) {
+void gles_draw_text(Text *txt) {
   // TODO: Implement this
 }

--- a/src/simple2d.c
+++ b/src/simple2d.c
@@ -16,7 +16,7 @@ char S2D_msg[1024];
 /*
  * Logs standard messages to the console
  */
-void S2D_Log(char *msg, int type) {
+void S2D_Log(const char *msg, int type) {
   
   if (diagnostics) {
     switch (type) {
@@ -39,7 +39,7 @@ void S2D_Log(char *msg, int type) {
 /*
  * Logs Simple 2D errors to the console, with caller and message body
  */
-void S2D_Error(char *caller, const char *msg) {
+void S2D_Error(const char *caller, const char *msg) {
   sprintf(S2D_msg, "(%s) %s", caller, msg);
   S2D_Log(S2D_msg, S2D_ERROR);
 }
@@ -94,29 +94,37 @@ void S2D_DrawQuad(GLfloat x1,  GLfloat y1,
 /*
  * Create an image
  */
-Image S2D_CreateImage(char *path) {
-  
+Image *S2D_CreateImage(const char *path) {
+  if(!path)
+      return NULL;
   // TODO: Implement images in GLES
   #if GLES
     S2D_Log("S2D_DrawImage not yet implemented!", S2D_INFO);
   #endif
   
-  Image img;
+  Image *img;
   SDL_Surface *surface;
   
   // Load image from file as SDL_Surface
   surface = IMG_Load(path);
   if (!surface) {
     S2D_Error("IMG_Load", IMG_GetError());
-    exit(1);
+    return NULL;
   }
-  
+
+  img = (Image *)malloc(sizeof(Image));
+  if(!img) {
+    S2D_Error("IMG_Load", "Out of memory!");
+    SDL_FreeSurface(surface);
+    return NULL;
+  }
+
   // Initialize values
-  img.x = 0;
-  img.y = 0;
-  img.w = surface->w;
-  img.h = surface->h;
-  img.texture_id = 0;
+  img->x = 0;
+  img->y = 0;
+  img->w = surface->w;
+  img->h = surface->h;
+  img->texture_id = 0;
   
   // Detect image mode
   // TODO: BMP is in BGR...?
@@ -125,7 +133,7 @@ Image S2D_CreateImage(char *path) {
     format = GL_RGBA;
   }
   
-  S2D_GL_SetUpTexture(&img.texture_id, format, img.w, img.h, surface->pixels, GL_NEAREST);
+  S2D_GL_SetUpTexture(&img->texture_id, format, img->w, img->h, surface->pixels, GL_NEAREST);
   
   // Free the surface data, no longer needed
   SDL_FreeSurface(surface);
@@ -137,7 +145,9 @@ Image S2D_CreateImage(char *path) {
 /*
  * Draw an image
  */
-void S2D_DrawImage(Image img) {
+void S2D_DrawImage(Image *img) {
+  if(!img)
+    return;
   S2D_GL_DrawImage(img);
 }
 
@@ -145,52 +155,62 @@ void S2D_DrawImage(Image img) {
 /*
  * Free an image
  */
-void S2D_FreeImage(Image img) {
-  S2D_GL_FreeTexture(&img.texture_id);
+void S2D_FreeImage(Image *img) {
+  if(!img)
+      return;
+  S2D_GL_FreeTexture(&img->texture_id);
+  free(img);
 }
 
 
 /*
  * Create text
  */
-Text S2D_CreateText(char *font, char *msg, int size) {
+Text *S2D_CreateText(const char *font, const char *msg, int size) {
   
   #if GLES
     S2D_Log("S2D_DrawText not yet implemented!", S2D_WARN);
   #endif
   
-  Text txt;
-  
-  // `msg` cannot be an empty string; if so, quit
-  if (strlen(msg) == 0) {
-    S2D_Error("S2D_CreateText", "Text message cannot be empty!");
-    exit(1);
-  } else {
-    txt.msg = msg;
+  Text *txt;
+
+  txt = (Text *)malloc(sizeof(Text));
+  if(!txt) {
+    S2D_Error("S2D_CreateText", "Out of memory!");
+    return NULL;
   }
   
-  txt.x = 0;
-  txt.y = 0;
-  txt.color.r = 1.0;
-  txt.color.g = 1.0;
-  txt.color.b = 1.0;
-  txt.color.a = 1.0;
-  txt.texture_id = 0;
+  // `msg` cannot be an empty string; if so, return
+  if (strlen(msg) == 0) {
+    S2D_Error("S2D_CreateText", "Text message cannot be empty!");
+    return NULL;
+  } else {
+    txt->msg = msg;
+  }
   
-  txt.font = TTF_OpenFont(font, size);
-  if (!txt.font) {
+  txt->x = 0;
+  txt->y = 0;
+  txt->color.r = 1.0;
+  txt->color.g = 1.0;
+  txt->color.b = 1.0;
+  txt->color.a = 1.0;
+  txt->texture_id = 0;
+  
+  txt->font = TTF_OpenFont(font, size);
+  if (!txt->font) {
     S2D_Error("TTF_OpenFont", TTF_GetError());
-    exit(1);
+    free(txt);
+    return NULL;
   }
   
   // Save the width and height of the text
-  TTF_SizeText(txt.font, txt.msg, &txt.w, &txt.h);
+  TTF_SizeText(txt->font, txt->msg, &txt->w, &txt->h);
   
   SDL_Surface *surface;
   SDL_Color color = { 255, 255, 255 };
-  surface = TTF_RenderText_Blended(txt.font, txt.msg, color);
+  surface = TTF_RenderText_Blended(txt->font, txt->msg, color);
   
-  S2D_GL_SetUpTexture(&txt.texture_id, GL_RGBA, txt.w, txt.h, surface->pixels, GL_NEAREST);
+  S2D_GL_SetUpTexture(&txt->texture_id, GL_RGBA, txt->w, txt->h, surface->pixels, GL_NEAREST);
   
   // Free the surface data, no longer needed
   SDL_FreeSurface(surface);
@@ -202,8 +222,11 @@ Text S2D_CreateText(char *font, char *msg, int size) {
 /*
  * Sets the text message
  */
-void S2D_SetText(Text *txt, char *msg) {
-  
+void S2D_SetText(Text *txt, const char *msg) {
+  if(!txt) {
+      return;
+  }
+
   txt->msg = msg;
   
   TTF_SizeText(txt->font, txt->msg, &txt->w, &txt->h);
@@ -221,7 +244,10 @@ void S2D_SetText(Text *txt, char *msg) {
 /*
  * Draw text
  */
-void S2D_DrawText(Text txt) {
+void S2D_DrawText(Text *txt) {
+  if(!txt) {
+    return;
+  }
   S2D_GL_DrawText(txt);
 }
 
@@ -229,20 +255,28 @@ void S2D_DrawText(Text txt) {
 /*
  * Free the text
  */
-void S2D_FreeText(Text txt) {
-  S2D_GL_FreeTexture(&txt.texture_id);
-  TTF_CloseFont(txt.font);
+void S2D_FreeText(Text *txt) {
+  if(!txt) {
+    return;
+  }
+  S2D_GL_FreeTexture(&txt->texture_id);
+  TTF_CloseFont(txt->font);
 }
 
 
 /*
  * Create a sound
  */
-Sound S2D_CreateSound(char *path) {
-  Sound sound;
+Sound *S2D_CreateSound(const char *path) {
+  Sound *sound;
+
+  sound = (Sound *)malloc(sizeof(Sound));
   
-  sound.data = Mix_LoadWAV(path);
-  if (!sound.data) S2D_Error("Mix_LoadWAV", Mix_GetError());
+  sound->data = Mix_LoadWAV(path);
+  if (!sound->data) {
+      S2D_Error("Mix_LoadWAV", Mix_GetError());
+      free(sound);
+  }
   
   return sound;
 }
@@ -251,27 +285,42 @@ Sound S2D_CreateSound(char *path) {
 /*
  * Play the sound
  */
-void S2D_PlaySound(Sound sound) {
-  Mix_PlayChannel(-1, sound.data, 0);
+void S2D_PlaySound(Sound *sound) {
+  if(!sound)
+      return;
+  Mix_PlayChannel(-1, sound->data, 0);
 }
 
 
 /*
  * Free the sound
  */
-void S2D_FreeSound(Sound sound) {
-  Mix_FreeChunk(sound.data);
+void S2D_FreeSound(Sound *sound) {
+  if(!sound)
+      return;
+  Mix_FreeChunk(sound->data);
+  free(sound);
 }
 
 
 /*
  * Create the music
  */
-Music S2D_CreateMusic(char *path) {
-  Music music;
-  
-  music.data = Mix_LoadMUS(path);
-  if (!music.data) S2D_Error("Mix_LoadMUS", Mix_GetError());
+Music *S2D_CreateMusic(const char *path) {
+  Music *music;
+
+  music = (Music *)malloc(sizeof(Music));
+  if(!music) {
+    S2D_Error("S2D_CreateMusic", "Out of memory!");
+    return NULL;
+  }
+
+  music->data = Mix_LoadMUS(path);
+  if (!music->data) {
+      S2D_Error("Mix_LoadMUS", Mix_GetError());
+      free(music);
+      return NULL;
+  }
   
   return music;
 }
@@ -280,9 +329,11 @@ Music S2D_CreateMusic(char *path) {
 /*
  * Play the music
  */
-void S2D_PlayMusic(Music music, int times) {
+void S2D_PlayMusic(Music *music, int times) {
+  if(!music)
+      return;
   // times: 0 == once, -1 == forever
-  if (Mix_PlayMusic(music.data, times) == -1) {
+  if (Mix_PlayMusic(music->data, times) == -1) {
     // No music for you
     S2D_Error("S2D_PlayMusic", Mix_GetError());
   }
@@ -324,15 +375,18 @@ void S2D_FadeOutMusic(int ms) {
 /*
  * Free the music
  */
-void S2D_FreeMusic(Music music) {
-  Mix_FreeMusic(music.data);
+void S2D_FreeMusic(Music *music) {
+  if(!music)
+      return;
+  Mix_FreeMusic(music->data);
+  free(music);
 }
 
 
 /*
  * Create a window
  */
-Window* S2D_CreateWindow(char *title, int width, int height,
+Window* S2D_CreateWindow(const char *title, int width, int height,
                          Update update, Render render, int flags) {
   
   // Allocate window and set default values
@@ -361,7 +415,8 @@ Window* S2D_CreateWindow(char *title, int width, int height,
   // Initialize SDL_ttf
   if (TTF_Init() != 0) {
     S2D_Error("TTF_Init", TTF_GetError());
-    exit(1);
+    free(window);
+    return NULL;
   }
   
   // Initialize SDL_mixer
@@ -378,7 +433,8 @@ Window* S2D_CreateWindow(char *title, int width, int height,
   
   if (Mix_OpenAudio(audio_rate, MIX_DEFAULT_FORMAT, audio_channels, audio_buffers) != 0) {
     S2D_Error("Mix_OpenAudio", Mix_GetError());
-    exit(1);
+    free(window);
+    return NULL;
   }
   
   // Create SDL window
@@ -467,7 +523,8 @@ Window* S2D_CreateWindow(char *title, int width, int height,
         // Could not create any OpenGL contexts, hard failure
         S2D_Error("GL2 / SDL_GL_CreateContext", SDL_GetError());
         S2D_Log("An OpenGL context could not be created", S2D_ERROR);
-        exit(1);
+        free(window);
+        return NULL;
       }
     #endif
   }

--- a/tests/audio.c
+++ b/tests/audio.c
@@ -109,6 +109,9 @@ int main(int argc, const char *argv[]) {
   window = S2D_CreateWindow(
     "Audio", 200, 150, NULL, NULL, 0
   );
+
+  if(!window)
+      return 1;
   
   window->on_key = on_key;
   

--- a/tests/audio.c
+++ b/tests/audio.c
@@ -3,10 +3,10 @@
 bool is_sound = true;
 int sound = 1;
 int music = 2;
-Sound snd_1;
-Sound snd_2;
-Music mus_1;
-Music mus_2;
+Sound *snd_1 = NULL;
+Sound *snd_2 = NULL;
+Music *mus_1 = NULL;
+Music *mus_2 = NULL;
 Window *window;
 
 void print_help() {
@@ -103,6 +103,8 @@ void on_key(const char *key) {
 }
 
 int main(int argc, const char *argv[]) {
+
+  S2D_Diagnostics(true);
   
   window = S2D_CreateWindow(
     "Audio", 200, 150, NULL, NULL, 0

--- a/tests/testcard.c
+++ b/tests/testcard.c
@@ -201,6 +201,8 @@ int main(int argc, const char *argv[]) {
   S2D_Diagnostics(true);
   
   window = S2D_CreateWindow("Simple 2D – Testcard", 600, 500, update, render, S2D_RESIZABLE);
+  if(!window)
+      return 1;
   
   window->on_key = on_key;
   window->on_key_down = on_key_down;

--- a/tests/testcard.c
+++ b/tests/testcard.c
@@ -2,18 +2,18 @@
 #include <simple2d.h>
 
 Window *window;
-Image img_bmp;
-Image img_jpg;
-Image img_png;
-Text txt;
-Text on_key_text;
-Text on_key_char;
-Text key_down_text;
-Text key_down_char;
-Text fps;
-Text fps_val;
+Image *img_bmp = NULL;
+Image *img_jpg = NULL;
+Image *img_png = NULL;
+Text *txt = NULL;
+Text *on_key_text = NULL;
+Text *on_key_char = NULL;
+Text *key_down_text = NULL;
+Text *key_down_char = NULL;
+Text *fps = NULL;
+Text *fps_val = NULL;
 char fps_str[7];
-char *font = "./media/bitstream_vera/vera.ttf";
+const char *font = "./media/bitstream_vera/vera.ttf";
 int font_size = 20;
 
 typedef struct Point {
@@ -25,11 +25,11 @@ Point pointer;
 
 void on_key(const char *key) {
   printf("Key pressed: %s\n", key);
-  S2D_SetText(&on_key_char, (char*)key);
+  S2D_SetText(on_key_char, key);
 }
 
 void on_key_down(const char *key) {
-  S2D_SetText(&key_down_char, (char*)key);
+  S2D_SetText(key_down_char, key);
 }
 
 void on_mouse(int x, int y) {
@@ -161,16 +161,16 @@ void render() {
   
   // Images
   
-  img_png.x = 300;
-  img_png.y = 0;
+  img_png->x = 300;
+  img_png->y = 0;
   S2D_DrawImage(img_png);
   
-  img_jpg.x = 400;
-  img_jpg.y = 0;
+  img_jpg->x = 400;
+  img_jpg->y = 0;
   S2D_DrawImage(img_jpg);
   
-  img_bmp.x = 500;
-  img_bmp.y = 0;
+  img_bmp->x = 500;
+  img_bmp->y = 0;
   S2D_DrawImage(img_bmp);
   
   // Text
@@ -184,7 +184,7 @@ void render() {
   
   S2D_DrawText(fps);
   snprintf(fps_str, 7, "%f", window->fps);
-  S2D_SetText(&fps_val, fps_str);
+  S2D_SetText(fps_val, fps_str);
   S2D_DrawText(fps_val);
   
   // Mouse positions
@@ -214,25 +214,25 @@ int main(int argc, const char *argv[]) {
   
   on_key_text = S2D_CreateText(font, "On Key:", font_size);
   on_key_char = S2D_CreateText(font, " ", font_size);
-  on_key_text.x = 5;
-  on_key_text.y = 270;
-  on_key_char.x = 90;
-  on_key_char.y = 270;
+  on_key_text->x = 5;
+  on_key_text->y = 270;
+  on_key_char->x = 90;
+  on_key_char->y = 270;
   
   key_down_text = S2D_CreateText(font, "On Key Down:", font_size);
   key_down_char = S2D_CreateText(font, " ", font_size);
-  key_down_text.x = 5;
-  key_down_text.y = 300;
-  key_down_char.x = 154;
-  key_down_char.y = 300;
+  key_down_text->x = 5;
+  key_down_text->y = 300;
+  key_down_char->x = 154;
+  key_down_char->y = 300;
   
   fps = S2D_CreateText(font, "FPS:", font_size);
-  fps.x = 460;
-  fps.y = 470;
+  fps->x = 460;
+  fps->y = 470;
   
   fps_val = S2D_CreateText(font, " ", font_size);
-  fps_val.x = 515;
-  fps_val.y = 470;
+  fps_val->x = 515;
+  fps_val->y = 470;
   
   S2D_Show(window);
   


### PR DESCRIPTION
Removed annoying `exit(1)` calls.
Returning NULL pointer on error is a proper way of error handling in C. Furthermore, it is not good idea to pass whole structures back and forth to functions, better pass a pointer to it to avoid unnecessary copying.

Updated tests.
