### PR TITLE
Add `S2D_Color` to Sprite

### DIFF
--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -211,6 +211,7 @@ typedef struct {
 // S2D_Sprite
 typedef struct {
   S2D_Image *img;
+  S2D_Color color;
   int x;
   int y;
   int width;

--- a/src/gl2.c
+++ b/src/gl2.c
@@ -105,7 +105,7 @@ void S2D_GL2_DrawImage(S2D_Image *img) {
 void S2D_GL2_DrawSprite(S2D_Sprite *spr) {
   S2D_GL2_DrawTexture(
     spr->x, spr->y, spr->width, spr->height,
-    spr->img->color.r, spr->img->color.g, spr->img->color.b, spr->img->color.a,
+    spr->color.r, spr->color.g, spr->color.b, spr->color.a,
     spr->tx1, spr->ty1, spr->tx2, spr->ty2, spr->tx3, spr->ty3, spr->tx4, spr->ty4,
     spr->img->texture_id
   );

--- a/src/gl3.c
+++ b/src/gl3.c
@@ -234,7 +234,7 @@ void S2D_GL3_DrawImage(S2D_Image *img) {
 void S2D_GL3_DrawSprite(S2D_Sprite *spr) {
   S2D_GL3_DrawTexture(
     spr->x, spr->y, spr->width, spr->height,
-    spr->img->color.r, spr->img->color.g, spr->img->color.b, spr->img->color.a,
+    spr->color.r, spr->color.g, spr->color.b, spr->color.a,
     spr->tx1, spr->ty1, spr->tx2, spr->ty2, spr->tx3, spr->ty3, spr->tx4, spr->ty4,
     spr->img->texture_id
   );

--- a/src/gles.c
+++ b/src/gles.c
@@ -267,7 +267,7 @@ void S2D_GLES_DrawImage(S2D_Image *img) {
 void S2D_GLES_DrawSprite(S2D_Sprite *spr) {
   S2D_GLES_DrawTexture(
     spr->x, spr->y, spr->width, spr->height,
-    spr->img->color.r, spr->img->color.g, spr->img->color.b, spr->img->color.a,
+    spr->color.r, spr->color.g, spr->color.b, spr->color.a,
     spr->tx1, spr->ty1, spr->tx2, spr->ty2, spr->tx3, spr->ty3, spr->tx4, spr->ty4,
     spr->img->texture_id
   );

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -19,6 +19,10 @@ S2D_Sprite *S2D_CreateSprite(const char *path) {
 
   spr->x = 0;
   spr->y = 0;
+  spr->color.r = 1.f;
+  spr->color.g = 1.f;
+  spr->color.b = 1.f;
+  spr->color.a = 1.f;
   spr->width  = spr->img->width;
   spr->height = spr->img->height;
   spr->clip_width  = spr->img->width;

--- a/test/testcard.c
+++ b/test/testcard.c
@@ -389,10 +389,10 @@ int main() {
   //   spr->width  = 100;
   //   spr->height = 100;
   // Change color of sprite
-  //   spr->img->color.r = 1.0;
-  //   spr->img->color.g = 1.0;
-  //   spr->img->color.b = 1.0;
-  //   spr->img->color.a = 1.0;
+  //   spr->color.r = 1.0;
+  //   spr->color.g = 1.0;
+  //   spr->color.b = 1.0;
+  //   spr->color.a = 1.0;
 
   txt_clr_r = S2D_CreateText(font, "R", font_size);
   txt_clr_r->x = 44;


### PR DESCRIPTION
Colors can now be accessed with simply `spr->color`, instead of `spr->img->color`