### PR TITLE
Added args to S2D_SetText function

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,9 @@ You can also change the text message at any time. Use `S2D_SetText` and provide 
 
 ```c
 S2D_SetText(txt, "A different message!");
+
+// Format text like with `printf`
+S2D_SetText(txt, "Welcome %s!", player);
 ```
 
 Since the text was allocated dynamically, you'll eventually need to free it using:

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -291,7 +291,7 @@ typedef struct {
   GLuint texture_id;
   TTF_Font *font;
   S2D_Color color;
-  const char *msg;
+  char *msg;
   int x;
   int y;
   int width;
@@ -439,7 +439,7 @@ S2D_Text *S2D_CreateText(const char *font, const char *msg, int size);
 /*
 * Sets the text message
 */
-void S2D_SetText(S2D_Text *txt, const char *msg);
+void S2D_SetText(S2D_Text *txt, const char *msg, ...);
 
 /*
  * Draw text

--- a/src/text.c
+++ b/src/text.c
@@ -26,7 +26,8 @@ S2D_Text *S2D_CreateText(const char *font, const char *msg, int size) {
   }
 
   // Set default values
-  txt->msg = msg;
+  txt->msg = (char *) malloc(strlen(msg) + 1 * sizeof(char));
+  strcpy(txt->msg, msg);
   txt->x = 0;
   txt->y = 0;
   txt->color.r = 1.f;
@@ -53,14 +54,20 @@ S2D_Text *S2D_CreateText(const char *font, const char *msg, int size) {
 /*
  * Sets the text message
  */
-void S2D_SetText(S2D_Text *txt, const char *msg) {
+void S2D_SetText(S2D_Text *txt, const char *msg, ...) {
   if (!txt) return;
 
   // `msg` cannot be an empty string or NULL for TTF_SizeText
   if (msg == NULL || strlen(msg) == 0) msg = " ";
 
-  txt->msg = msg;
+  // Format and store new text string
+  va_list args;
+  va_start(args, msg);
+  free(txt->msg);
+  vasprintf(&txt->msg, msg, args);
+  va_end(args);
 
+  // Save the width and height of the text
   TTF_SizeText(txt->font, txt->msg, &txt->width, &txt->height);
 
   // Delete the current texture so a new one can be generated
@@ -92,6 +99,7 @@ void S2D_DrawText(S2D_Text *txt) {
  */
 void S2D_FreeText(S2D_Text *txt) {
   if (!txt) return;
+  free(txt->msg);
   S2D_GL_FreeTexture(&txt->texture_id);
   TTF_CloseFont(txt->font);
   free(txt);

--- a/test/testcard.c
+++ b/test/testcard.c
@@ -16,7 +16,6 @@ S2D_Text   *txt_clr_b;
 S2D_Text   *fps;
 S2D_Text   *fps_val;
 
-char fps_str[7];
 const char *font = "media/bitstream_vera/vera.ttf";
 int font_size = 20;
 
@@ -309,8 +308,7 @@ void render() {
   // Window stats
 
   S2D_DrawText(fps);
-  snprintf(fps_str, 7, "%f", window->fps);
-  if (window->frames % 20 == 0) S2D_SetText(fps_val, fps_str);
+  if (window->frames % 20 == 0) S2D_SetText(fps_val, "%f", window->fps);
   S2D_DrawText(fps_val);
 
   // Mouse positions
@@ -424,11 +422,11 @@ int main() {
   txt_clr_b->color.a = 1.0;
 
   fps = S2D_CreateText(font, "FPS:", font_size);
-  fps->x = 460;
+  fps->x = 430;
   fps->y = 470;
 
   fps_val = S2D_CreateText(font, "", font_size);
-  fps_val->x = 515;
+  fps_val->x = 480;
   fps_val->y = 470;
 
   S2D_Show(window);


### PR DESCRIPTION
Now we can use the S2D_SetText like the printf function. The only problem is that the text must have 512 characters (but it can changed to other values), because we can not predict the length of the string with args, but I think this is not a real problem.