### PR TITLE
OpenGL 3.3+ batch rendering

### DIFF
--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -687,6 +687,7 @@ void S2D_GL_DrawSprite(S2D_Sprite *spr);
 void S2D_GL_DrawText(S2D_Text *txt);
 void S2D_GL_FreeTexture(GLuint *id);
 void S2D_GL_Clear(S2D_Color clr);
+void S2D_GL_FlushBuffers();
 
 // OpenGL & GLES Internal Functions ////////////////////////////////////////////
 
@@ -728,6 +729,7 @@ void S2D_GL_Clear(S2D_Color clr);
   void S2D_GL3_DrawSprite(S2D_Sprite *spr);
   void S2D_GL2_DrawText(S2D_Text *txt);
   void S2D_GL3_DrawText(S2D_Text *txt);
+  void S2D_GL3_FlushBuffers();
 #endif
 
 #ifdef __cplusplus

--- a/src/gl.c
+++ b/src/gl.c
@@ -409,6 +409,19 @@ void S2D_GL_DrawText(S2D_Text *txt) {
 
 
 /*
+ * Render and flush OpenGL buffers
+ */
+void S2D_GL_FlushBuffers() {
+  // Only implemented in our OpenGL 3.3+ and ES 2.0 renderers
+  #if GLES
+    // TODO: S2D_GLES_FlushBuffers();
+  #else
+    if (!S2D_GL2) S2D_GL3_FlushBuffers();
+  #endif
+}
+
+
+/*
  * Clear buffers to given color values
  */
 void S2D_GL_Clear(S2D_Color clr) {

--- a/src/window.c
+++ b/src/window.c
@@ -314,6 +314,9 @@ int S2D_Show(S2D_Window *window) {
 
     // Draw Frame //////////////////////////////////////////////////////////////
 
+    // Render and flush all OpenGL buffers
+    S2D_GL_FlushBuffers();
+
     // Swap buffers to display drawn contents in the window
     SDL_GL_SwapWindow(window->sdl);
   }


### PR DESCRIPTION
36.4x faster triangle draw speed. 😮
Max of 21,840,000 triangles rendered per second at 60 FPS on my MacBook Pro (increase from 600,000).