### PR TITLE
Adding volume control support for sounds and sound mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,18 +582,18 @@ Play the sound like this:
 S2D_PlaySound(snd);
 ```
 
-The volume of all Sounds can be inspected and set with the following functions. Volume is expressed as range between 0 (softest) and 100 (loudest).
-
-```c
-int volume = S2D_GetSoundMixVolume();
-S2D_SetSoundMixVolume(50);  // set volume 50%
-```
-
-Similarly, the volume of a single S2D_Sound can be inspected and set as well
+You can get and set the volume of a sound like so:
 
 ```c
 int volume = S2D_GetSoundVolume(snd);
 S2D_SetSoundVolume(snd, 50);  // set volume 50%
+```
+
+In addition, get and set the volume of all sounds like this, where the volume is a range between 0 (softest) and 100 (loudest):
+
+```c
+int volume = S2D_GetSoundMixVolume();
+S2D_SetSoundMixVolume(50);  // set volume 50%
 ```
 
 Since sounds are allocated dynamically, free them using:

--- a/README.md
+++ b/README.md
@@ -582,6 +582,20 @@ Play the sound like this:
 S2D_PlaySound(snd);
 ```
 
+The volume of all Sounds can be inspected and set with the following functions. Volume is expressed as range between 0 (softest) and 100 (loudest).
+
+```c
+int volume = S2D_GetSoundMixVolume();
+S2D_SetSoundMixVolume(50);  // set volume 50%
+```
+
+Similarly, the volume of a single S2D_Sound can be inspected and set as well
+
+```c
+int volume = S2D_GetSoundVolume(snd);
+S2D_SetSoundVolume(snd, 50);  // set volume 50%
+```
+
 Since sounds are allocated dynamically, free them using:
 
 ```c

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -537,9 +537,30 @@ S2D_Sound *S2D_CreateSound(const char *path);
 void S2D_PlaySound(S2D_Sound *snd);
 
 /*
+ * Get the sound's volume
+ */
+int S2D_GetSoundVolume(S2D_Sound *snd);
+
+/*
+ * Set the sound's volume a given percentage
+ */
+void S2D_SetSoundVolume(S2D_Sound *snd, int volume);
+
+/*
  * Free the sound
  */
 void S2D_FreeSound(S2D_Sound *snd);
+
+/*
+ * Get the sound mixer volume
+ */
+int S2D_GetSoundMixVolume();
+
+/*
+ * Set the sound mixer volume a given percentage
+ */
+void S2D_SetSoundMixVolume(int volume);
+
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -547,11 +547,6 @@ int S2D_GetSoundVolume(S2D_Sound *snd);
 void S2D_SetSoundVolume(S2D_Sound *snd, int volume);
 
 /*
- * Free the sound
- */
-void S2D_FreeSound(S2D_Sound *snd);
-
-/*
  * Get the sound mixer volume
  */
 int S2D_GetSoundMixVolume();
@@ -561,6 +556,10 @@ int S2D_GetSoundMixVolume();
  */
 void S2D_SetSoundMixVolume(int volume);
 
+/*
+ * Free the sound
+ */
+void S2D_FreeSound(S2D_Sound *snd);
 
 // Music ///////////////////////////////////////////////////////////////////////
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -54,3 +54,39 @@ void S2D_FreeSound(S2D_Sound *snd) {
   Mix_FreeChunk(snd->data);
   free(snd);
 }
+
+
+/*
+ * Gets the mix volume for the sound chunk
+ */
+int S2D_GetSoundVolume(S2D_Sound *snd) {
+  if (!snd) return 0;
+  return ceil(Mix_VolumeChunk(snd->data, -1) * (100.0 / MIX_MAX_VOLUME));
+}
+
+/*
+ * Sets the mix volume for the sound chunk
+ */
+void S2D_SetSoundVolume(S2D_Sound *snd, int volume) {
+  if (!snd) return;
+  // Set volume to be a percentage of the maximum mix volume
+  Mix_VolumeChunk(snd->data, (volume / 100.0) * MIX_MAX_VOLUME);
+}
+
+
+/*
+ * Get the sound mixer volume
+ */
+int S2D_GetSoundMixVolume() {
+  return ceil(Mix_Volume(-1, -1) * (100.0 / MIX_MAX_VOLUME));
+}
+
+
+/*
+ * Set the sound mixer volume a given percentage
+ * Sets the value across all channels
+ */
+void S2D_SetSoundMixVolume(int volume) {
+  // Set volume to be a percentage of the maximum mix volume
+  Mix_Volume(-1, (volume / 100.0) * MIX_MAX_VOLUME);
+}

--- a/src/sound.c
+++ b/src/sound.c
@@ -47,25 +47,16 @@ void S2D_PlaySound(S2D_Sound *snd) {
 
 
 /*
- * Free the sound
- */
-void S2D_FreeSound(S2D_Sound *snd) {
-  if (!snd) return;
-  Mix_FreeChunk(snd->data);
-  free(snd);
-}
-
-
-/*
- * Gets the mix volume for the sound chunk
+ * Get the sound's volume
  */
 int S2D_GetSoundVolume(S2D_Sound *snd) {
-  if (!snd) return 0;
+  if (!snd) return -1;
   return ceil(Mix_VolumeChunk(snd->data, -1) * (100.0 / MIX_MAX_VOLUME));
 }
 
+
 /*
- * Sets the mix volume for the sound chunk
+ * Set the sound's volume a given percentage
  */
 void S2D_SetSoundVolume(S2D_Sound *snd, int volume) {
   if (!snd) return;
@@ -84,9 +75,19 @@ int S2D_GetSoundMixVolume() {
 
 /*
  * Set the sound mixer volume a given percentage
- * Sets the value across all channels
  */
 void S2D_SetSoundMixVolume(int volume) {
+  // This sets the volume value across all channels
   // Set volume to be a percentage of the maximum mix volume
   Mix_Volume(-1, (volume / 100.0) * MIX_MAX_VOLUME);
+}
+
+
+/*
+ * Free the sound
+ */
+void S2D_FreeSound(S2D_Sound *snd) {
+  if (!snd) return;
+  Mix_FreeChunk(snd->data);
+  free(snd);
 }


### PR DESCRIPTION
Adding support for volume control in response to Ruby2d issue: https://github.com/ruby2d/ruby2d/issues/115

Implemented two ways to handle this, S2D_GetSoundVolume and S2D_SetSoundVolume set the volume mix for a particular sound. Additionally, S2D_GetSoundMixVolume and S2D_SetSoundMixVolume set the volume for the whole mixer. For simplicity's sake, all channels are set to the same volume value.