### PR TITLE
docs: fix simple typo, dimentions -> dimensions

### DIFF
--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -376,7 +376,7 @@ void S2D_Windows_EnableTerminalColors();
 bool S2D_Init();
 
 /*
- * Gets the primary display's dimentions
+ * Gets the primary display's dimensions
  */
 void S2D_GetDisplayDimensions(int *w, int *h);
 

--- a/src/simple2d.c
+++ b/src/simple2d.c
@@ -161,7 +161,7 @@ bool S2D_Init() {
 
 
 /*
- * Gets the primary display's dimentions
+ * Gets the primary display's dimensions
  */
 void S2D_GetDisplayDimensions(int *w, int *h) {
   S2D_Init();


### PR DESCRIPTION
There is a small typo in include/simple2d.h, src/simple2d.c.

Should read `dimensions` rather than `dimentions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md