### PR TITLE
Support for decimal positions and sizes, window position control, and on_quit callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ Before showing the window, these attributes can be set:
 ```c
 window->vsync = false;     // set the vertical sync, true by default
 window->icon = "app.png";  // set the icon for the window
+
+// Set the initial position of the window on screen when it opens.
+// In fullscreen mode it will snap to fill whichever monitor it is "more in"
+// Defaults to center
+window->pos_x = 50; //left side of window is 50 pixels from left edge of screen
+window->pos_y = 0; //top of window is at top of screen
 ```
 
 Once your window is ready to go, show it using:
@@ -310,7 +316,21 @@ To exit the window loop at any time, use:
 ```c
 S2D_Close(window);
 ```
-
+Note, this does not call the `on_close` handler (see below), it closes the window immediately.
+#### Close button on window
+By  default, the window will always close when the `X` or close button is clicked on the window. This can be changed by adding a callback for `on_close` to the window. This function should look like this:
+```c
+bool on_close(){ return isReadyToQuit; } /* Return true for quit, false for stay open */
+```
+Then, to attach it to the window:
+```c
+window->on_close = on_close;
+```
+The function should return `true` if the window should close, or `false` if the window should stay open and the close button click should be ignored.
+A example use would be confirming a close with the user.
+```c
+bool on_close(){ return userConfirmQuitting(); } /* For example, ask the user before quitting */
+```
 ## Drawing
 
 All kinds of shapes and textures can be drawn in the window. Learn about each of them below.
@@ -440,6 +460,10 @@ S2D_Sprite *spr = S2D_CreateSprite("sprite_sheet.png");
 
 If the sprite image can't be found, it will return `NULL`.
 
+There is a handy `num_images` member available in a sprite struct. It can be used to remember how many images are on the sprite sheet for animationss. This is not used by Simple 2D itself, but is useful to you for making animated sprites.
+```c
+spr->num_images = 50; //remember that there are 50 different images in the sprite sheet.`_
+```
 Clip the sprite sheet to a single image by providing a clipping rectangle:
 
 ```c

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ If the sprite image can't be found, it will return `NULL`.
 
 There is a handy `num_images` member available in a sprite struct. It can be used to remember how many images are on the sprite sheet for animationss. This is not used by Simple 2D itself, but is useful to you for making animated sprites.
 ```c
-spr->num_images = 50; //remember that there are 50 different images in the sprite sheet.`_
+spr->num_images = 50; //store the fact that there are 50 different images in the sprite sheet.`_
 ```
 Clip the sprite sheet to a single image by providing a clipping rectangle:
 

--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ To capture keyboard input, first define the `on_key()` function and read the eve
 ```c
 void on_key(S2D_Event e) {
   // Check `e.key` for the key being interacted with
-
+  // e.value will give the SDL_Scancode of the key, useful for identifying each key as a number
   switch (e.type) {
     case S2D_KEY_DOWN:
       // Key was pressed

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ By  default, the window will always close when the `X` or close button is clicke
 ```c
 bool on_close(){ return isReadyToQuit; } /* Return true for quit, false for stay open */
 ```
-Then, to attach it to the window:
+Then, attach the callback to the window:
 ```c
 window->on_close = on_close;
 ```
@@ -460,9 +460,9 @@ S2D_Sprite *spr = S2D_CreateSprite("sprite_sheet.png");
 
 If the sprite image can't be found, it will return `NULL`.
 
-There is a handy `num_images` member available in a sprite struct. It can be used to remember how many images are on the sprite sheet for animationss. This is not used by Simple 2D itself, but is useful to you for making animated sprites.
+There is a handy `num_images` member available in the sprite struct. It can be used to remember how many images are on the sprite sheet for animations. This is not used by Simple 2D itself, but is useful to you for making animated sprites.
 ```c
-spr->num_images = 50; //store the fact that there are 50 different images in the sprite sheet.`_
+spr->num_images = 50; //store the fact that there are 50 different images in the sprite sheet.`
 ```
 Clip the sprite sheet to a single image by providing a clipping rectangle:
 

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -253,8 +253,8 @@ typedef struct {
   const char *title;
   int width;
   int height;
-  int posX;
-  int posY;
+  int pos_x;
+  int pos_y;
   int orig_width;
   int orig_height;
   S2D_Viewport viewport;

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -289,8 +289,8 @@ typedef struct {
   double y;
   double width;
   double height;
-  double orig_width;
-  double orig_height;
+  int orig_width;
+  int orig_height;
   GLfloat rotate;  // Rotation angle in degrees
   GLfloat rx;      // X coordinate to be rotated around
   GLfloat ry;      // Y coordinate to be rotated around

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -1,4 +1,7 @@
 // simple2d.h
+#ifdef _MSC_VER
+#pragma once
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -303,7 +303,7 @@ typedef struct {
   S2D_Color color;
   double x;
   double y;
-  double num_images;
+  int num_images;
   double width;
   double height;
   double clip_width;

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -1,5 +1,4 @@
 // simple2d.h
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -208,6 +207,7 @@ typedef void (*S2D_Render)();
 typedef void (*S2D_On_Key)(S2D_Event e);
 typedef void (*S2D_On_Mouse)(S2D_Event e);
 typedef void (*S2D_On_Controller)(S2D_Event e);
+typedef bool (*S2D_On_Close)();
 
 // S2D_GL_Point, for graphics calculations
 typedef struct {
@@ -250,11 +250,14 @@ typedef struct {
   const char *title;
   int width;
   int height;
+  int posX;
+  int posY;
   int orig_width;
   int orig_height;
   S2D_Viewport viewport;
   S2D_Update update;
   S2D_Render render;
+  S2D_On_Close on_close;
   int flags;
   S2D_Mouse mouse;
   S2D_On_Key on_key;
@@ -279,12 +282,12 @@ typedef struct {
   int format;
   GLuint texture_id;
   S2D_Color color;
-  int x;
-  int y;
-  int width;
-  int height;
-  int orig_width;
-  int orig_height;
+  double x;
+  double y;
+  double width;
+  double height;
+  double orig_width;
+  double orig_height;
   GLfloat rotate;  // Rotation angle in degrees
   GLfloat rx;      // X coordinate to be rotated around
   GLfloat ry;      // Y coordinate to be rotated around
@@ -295,12 +298,13 @@ typedef struct {
   const char *path;
   S2D_Image *img;
   S2D_Color color;
-  int x;
-  int y;
-  int width;
-  int height;
-  int clip_width;
-  int clip_height;
+  double x;
+  double y;
+  double num_images;
+  double width;
+  double height;
+  double clip_width;
+  double clip_height;
   GLfloat rotate;  // Rotation angle in degrees
   GLfloat rx;      // X coordinate to be rotated around
   GLfloat ry;      // Y coordinate to be rotated around
@@ -322,8 +326,8 @@ typedef struct {
   TTF_Font *font_data;
   S2D_Color color;
   char *msg;
-  int x;
-  int y;
+  double x;
+  double y;
   int width;
   int height;
   GLfloat rotate;  // Rotation angle in degrees
@@ -476,7 +480,6 @@ void S2D_FreeImage(S2D_Image *img);
  * Create a sprite, given an image file path
  */
 S2D_Sprite *S2D_CreateSprite(const char *path);
-
 /*
  * Clip a sprite
  */

--- a/include/simple2d.h
+++ b/include/simple2d.h
@@ -285,10 +285,10 @@ typedef struct {
   int format;
   GLuint texture_id;
   S2D_Color color;
-  double x;
-  double y;
-  double width;
-  double height;
+  GLfloat x;
+  GLfloat y;
+  GLfloat width;
+  GLfloat height;
   int orig_width;
   int orig_height;
   GLfloat rotate;  // Rotation angle in degrees
@@ -301,13 +301,13 @@ typedef struct {
   const char *path;
   S2D_Image *img;
   S2D_Color color;
-  double x;
-  double y;
+  GLfloat x;
+  GLfloat y;
   int num_images;
-  double width;
-  double height;
-  double clip_width;
-  double clip_height;
+  GLfloat width;
+  GLfloat height;
+  GLfloat clip_width;
+  GLfloat clip_height;
   GLfloat rotate;  // Rotation angle in degrees
   GLfloat rx;      // X coordinate to be rotated around
   GLfloat ry;      // Y coordinate to be rotated around
@@ -329,8 +329,8 @@ typedef struct {
   TTF_Font *font_data;
   S2D_Color color;
   char *msg;
-  double x;
-  double y;
+  GLfloat x;
+  GLfloat y;
   int width;
   int height;
   GLfloat rotate;  // Rotation angle in degrees

--- a/src/gl2.c
+++ b/src/gl2.c
@@ -66,7 +66,7 @@ void S2D_GL2_DrawTriangle(GLfloat x1, GLfloat y1,
 /*
  * Draw texture
  */
-static void S2D_GL2_DrawTexture(int x, int y, int w, int h,
+static void S2D_GL2_DrawTexture(double x, double y, double w, double h,
                                 GLfloat angle, GLfloat rx, GLfloat ry,
                                 GLfloat r, GLfloat g, GLfloat b, GLfloat a,
                                 GLfloat tx1, GLfloat ty1, GLfloat tx2, GLfloat ty2,

--- a/src/gl2.c
+++ b/src/gl2.c
@@ -66,7 +66,7 @@ void S2D_GL2_DrawTriangle(GLfloat x1, GLfloat y1,
 /*
  * Draw texture
  */
-static void S2D_GL2_DrawTexture(double x, double y, double w, double h,
+static void S2D_GL2_DrawTexture(GLfloat x, GLfloat y, GLfloat w, GLfloat h,
                                 GLfloat angle, GLfloat rx, GLfloat ry,
                                 GLfloat r, GLfloat g, GLfloat b, GLfloat a,
                                 GLfloat tx1, GLfloat ty1, GLfloat tx2, GLfloat ty2,

--- a/src/gl3.c
+++ b/src/gl3.c
@@ -256,7 +256,7 @@ void S2D_GL3_DrawTriangle(GLfloat x1, GLfloat y1,
 /*
  * Draw a texture
  */
-static void S2D_GL3_DrawTexture(double x, double y, double w, double h,
+static void S2D_GL3_DrawTexture(GLfloat x, GLfloat y, GLfloat w, GLfloat h,
                                 GLfloat angle, GLfloat rx, GLfloat ry,
                                 GLfloat r, GLfloat g, GLfloat b, GLfloat a,
                                 GLfloat tx1, GLfloat ty1, GLfloat tx2, GLfloat ty2,

--- a/src/gl3.c
+++ b/src/gl3.c
@@ -256,7 +256,7 @@ void S2D_GL3_DrawTriangle(GLfloat x1, GLfloat y1,
 /*
  * Draw a texture
  */
-static void S2D_GL3_DrawTexture(int x, int y, int w, int h,
+static void S2D_GL3_DrawTexture(double x, double y, double w, double h,
                                 GLfloat angle, GLfloat rx, GLfloat ry,
                                 GLfloat r, GLfloat g, GLfloat b, GLfloat a,
                                 GLfloat tx1, GLfloat ty1, GLfloat tx2, GLfloat ty2,

--- a/src/gl3.c
+++ b/src/gl3.c
@@ -207,7 +207,7 @@ int S2D_GL3_Init() {
  * Render the vertex buffer and reset it
  */
 void S2D_GL3_FlushBuffers() {
-
+  if (vboDataIndex == 0) { return; } // no need to do anything if nothing in buffer
   // Use the triangle shader program
   glUseProgram(shaderProgram);
 

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -33,6 +33,7 @@ S2D_Sprite *S2D_CreateSprite(const char *path) {
   spr->path = path;
   spr->x = 0;
   spr->y = 0;
+  spr->num_images = 0;
   spr->color.r = 1.f;
   spr->color.g = 1.f;
   spr->color.b = 1.f;

--- a/src/window.c
+++ b/src/window.c
@@ -172,7 +172,7 @@ int S2D_Show(S2D_Window *window) {
         case SDL_KEYDOWN:
           if (window->on_key && e.key.repeat == 0) {
             S2D_Event event = {
-              .type = S2D_KEY_DOWN, .key = SDL_GetScancodeName(e.key.keysym.scancode)
+              .type = S2D_KEY_DOWN, .key = SDL_GetScancodeName(e.key.keysym.scancode), .value=e.key.keysym.scancode
             };
             window->on_key(event);
           }
@@ -181,7 +181,7 @@ int S2D_Show(S2D_Window *window) {
         case SDL_KEYUP:
           if (window->on_key) {
             S2D_Event event = {
-              .type = S2D_KEY_UP, .key = SDL_GetScancodeName(e.key.keysym.scancode)
+              .type = S2D_KEY_UP, .key = SDL_GetScancodeName(e.key.keysym.scancode), .value= e.key.keysym.scancode
             };
             window->on_key(event);
           }
@@ -307,7 +307,7 @@ int S2D_Show(S2D_Window *window) {
         if (key_state[i] == 1) {
 
           S2D_Event event = {
-            .type = S2D_KEY_HELD, .key = SDL_GetScancodeName(i)
+            .type = S2D_KEY_HELD, .key = SDL_GetScancodeName(i), .value=i
           };
           window->on_key(event);
         }

--- a/src/window.c
+++ b/src/window.c
@@ -172,7 +172,7 @@ int S2D_Show(S2D_Window *window) {
         case SDL_KEYDOWN:
           if (window->on_key && e.key.repeat == 0) {
             S2D_Event event = {
-              .type = S2D_KEY_DOWN, .key = SDL_GetScancodeName(e.key.keysym.scancode), .value=e.key.keysym.scancode
+              .type = S2D_KEY_DOWN, .key = SDL_GetScancodeName(e.key.keysym.scancode)
             };
             window->on_key(event);
           }
@@ -181,7 +181,7 @@ int S2D_Show(S2D_Window *window) {
         case SDL_KEYUP:
           if (window->on_key) {
             S2D_Event event = {
-              .type = S2D_KEY_UP, .key = SDL_GetScancodeName(e.key.keysym.scancode), .value= e.key.keysym.scancode
+              .type = S2D_KEY_UP, .key = SDL_GetScancodeName(e.key.keysym.scancode)
             };
             window->on_key(event);
           }
@@ -307,7 +307,7 @@ int S2D_Show(S2D_Window *window) {
         if (key_state[i] == 1) {
 
           S2D_Event event = {
-            .type = S2D_KEY_HELD, .key = SDL_GetScancodeName(i), .value=i
+            .type = S2D_KEY_HELD, .key = SDL_GetScancodeName(i)
           };
           window->on_key(event);
         }

--- a/src/window.c
+++ b/src/window.c
@@ -27,8 +27,8 @@ S2D_Window *S2D_CreateWindow(const char *title, int width, int height,
   window->height          = height;
   window->orig_width      = width;
   window->orig_height     = height;
-  window->posX            = SDL_WINDOWPOS_CENTERED;
-  window->posY            = SDL_WINDOWPOS_CENTERED;
+  window->pos_x            = SDL_WINDOWPOS_CENTERED;
+  window->pos_y            = SDL_WINDOWPOS_CENTERED;
   window->viewport.width  = width;
   window->viewport.height = height;
   window->viewport.mode   = S2D_SCALE;
@@ -66,7 +66,7 @@ int S2D_Show(S2D_Window *window) {
   // Create SDL window
   window->sdl = SDL_CreateWindow(
     window->title,                                   // title
-    window->posX, window->posY,  // window position
+    window->pos_x, window->pos_y,  // window position
     window->width, window->height,                   // window size
     SDL_WINDOW_OPENGL | window->flags                // flags
   );


### PR DESCRIPTION
I added the ability to set images, sprites, and text to be positioned and scaled using decimal (GLfloat) values, for a much smoother experience when moving and resizing. 

I also added a on_close callback to the window, to allow applications to confirm closing and do cleanup.
Added positional control for where the window is created.
Also made a num_images member on the sprite struct, to allow easier control of sprites by the user, even though it is not used internally.

Added the key's scancode to the S2D events for keys in the value field.

And I added these things to the docs in the Readme.md. 

I also made a small but very effective change to not flush the vertex buffer if it is empty. This way if only images are being drawn no time is wasted trying to flush an empty buffer. In my app it almost doubled FPS.  If there *are* triangles, the z ordering is still conserved like normal. 

There should be no breaking changes to the library, just some added features.
