### PR TITLE
Repack font texture surface

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -107,6 +107,17 @@ void S2D_DrawText(S2D_Text *txt) {
       S2D_Error("TTF_RenderText_Blended", TTF_GetError());
       return;
     }
+
+    Uint32 len = txt->surface->w * 4;  // GL_RGBA is 4 bytes per pixel
+    Uint8 *src = txt->surface->pixels;
+    Uint8 *dst = txt->surface->pixels;
+    for (int i = 0; i < txt->surface->h; i++) {
+      SDL_memmove(dst, src, len);
+      dst += len;
+      src += txt->surface->pitch;
+    }
+    txt->surface->pitch = len;
+
     S2D_GL_CreateTexture(&txt->texture_id, GL_RGBA,
                          txt->width, txt->height,
                          txt->surface->pixels, GL_NEAREST);


### PR DESCRIPTION
Fix issues:
 - https://github.com/simple2d/simple2d/issues/140
 - https://github.com/simple2d/simple2d/issues/134

Based on the [link provided](https://discourse.libsdl.org/t/sdl-ttf-2-0-18-surface-to-opengl-texture-not-consistent-with-ttf-2-0-15/34529/2) regarding a change in SDL_ttf 2.0.18, repack the texture so it renders correctly.

Before:
![Screenshot_20240407_141625](https://github.com/simple2d/simple2d/assets/15974789/8d059b4d-54dc-4cfc-be44-a9bad96f2232)
After:
![Screenshot_20240407_141335](https://github.com/simple2d/simple2d/assets/15974789/06ce861e-a981-4da6-b989-f569dd3ec95c)